### PR TITLE
factuurInputRegel: store int instead of float in stukprijs and totaalprijs

### DIFF
--- a/factuurinput/factuurInputRegel.py
+++ b/factuurinput/factuurInputRegel.py
@@ -90,12 +90,12 @@ class FactuurInputRegel(Container):
             (isOk, stukprijs) = parseMoney(self.fieldControl[2].text)
             if not isOk:
                 return (False, False, "Invalid stukprijs")
-            result['stukprijs'] = math.ceil(stukprijs * mult)
+            result['stukprijs'] = int(math.ceil(stukprijs * mult))
         if self.fieldControl[3].text != "":
             (isOk, totaalprijs) = parseMoney(self.fieldControl[3].text)
             if not isOk:
                 return (False, False, "Invalid totaalprijs")
-            result['totaalprijs'] = math.ceil(totaalprijs * mult)
+            result['totaalprijs'] = int(math.ceil(totaalprijs * mult))
 
         return (True, True, result)
 


### PR DESCRIPTION
The values are stored as floats, while the server expects ints. The server fails when using this code.

via @kashout
